### PR TITLE
fix: Pin sha of nginx:latest

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,3 @@
 # syntax=docker/dockerfile:1
-FROM nginx:latest
+FROM nginx:latest@sha256:10d1f5b58f74683ad34eb29287e07dab1e90f10af243f151bb50aa5dbb4d62ee
 COPY resources/nginx.conf /etc/nginx/conf.d/default.conf


### PR DESCRIPTION
This pins the sha of the Docker image for nginx:latest.