### PR TITLE
fix: Add regex for web.keyman.com.localhost

### DIFF
--- a/resources/nginx.conf
+++ b/resources/nginx.conf
@@ -31,7 +31,7 @@ server {
 server {
   listen       80;
   listen  [::]:80;
-  server_name  ~^(web.)?keyman(web)?.com.localhost;
+  server_name  ~^(web\.keyman|keymanweb).com.localhost;
   location / {
     proxy_pass http://host.docker.internal:8057;
   }

--- a/resources/nginx.conf
+++ b/resources/nginx.conf
@@ -31,7 +31,7 @@ server {
 server {
   listen       80;
   listen  [::]:80;
-  server_name  ~^(web\.keyman|keymanweb).com.localhost;
+  server_name  ~^(web\.keyman|keymanweb)\.com\.localhost;
   location / {
     proxy_pass http://host.docker.internal:8057;
   }

--- a/resources/nginx.conf
+++ b/resources/nginx.conf
@@ -31,7 +31,7 @@ server {
 server {
   listen       80;
   listen  [::]:80;
-  server_name  keymanweb.com.localhost;
+  server_name  ~^(web.)?keyman(web)?.com.localhost;
   location / {
     proxy_pass http://host.docker.internal:8057;
   }


### PR DESCRIPTION
Addresses comment on https://github.com/keymanapp/keyman/pull/10566#discussion_r1472195112

Tweaks regex so web.keyman.com.localhost and keymanweb.com.localhost correctly brings up the keymanweb site
