### PR TITLE
chore: add status.keyman.com.localhost and accept live host requests also

### DIFF
--- a/resources/nginx.conf
+++ b/resources/nginx.conf
@@ -4,7 +4,7 @@
 server {
   listen       80;
   listen  [::]:80;
-  server_name  api.keyman.com.localhost;
+  server_name  api.keyman.com.localhost api.keyman.com;
   location / {
     proxy_pass http://host.docker.internal:8058;
   }
@@ -13,7 +13,7 @@ server {
 server {
   listen       80;
   listen  [::]:80;
-  server_name  help.keyman.com.localhost;
+  server_name  help.keyman.com.localhost help.keyman.com;
   location / {
     proxy_pass http://host.docker.internal:8055;
   }
@@ -22,7 +22,7 @@ server {
 server {
   listen       80;
   listen  [::]:80;
-  server_name  keyman.com.localhost;
+  server_name  keyman.com.localhost keyman.com;
   location / {
     proxy_pass http://host.docker.internal:8053;
   }
@@ -31,7 +31,7 @@ server {
 server {
   listen       80;
   listen  [::]:80;
-  server_name  ~^(web\.keyman|keymanweb)\.com\.localhost;
+  server_name  web.keyman.com.localhost keymanweb.com.localhost web.keyman.com keymanweb.com;
   location / {
     proxy_pass http://host.docker.internal:8057;
   }
@@ -40,8 +40,29 @@ server {
 server {
   listen       80;
   listen  [::]:80;
-  server_name  s.keyman.com.localhost;
+  server_name  s.keyman.com.localhost s.keyman.com;
   location / {
     proxy_pass http://host.docker.internal:8054;
+  }
+}
+
+# note that in production, this port is not used for status.keyman.com
+server {
+  listen       80;
+  listen  [::]:80;
+  server_name  status.keyman.com.localhost status.keyman.com;
+  location / {
+    proxy_pass http://host.docker.internal:8061;
+  }
+}
+
+# in development mode, backend is separate to frontend for status.keyman.com
+# note that in production, 8060 is the backend and frontend!
+server {
+  listen       80;
+  listen  [::]:80;
+  server_name  status-backend.keyman.com.localhost status-backend.keyman.com;
+  location / {
+    proxy_pass http://host.docker.internal:8060;
   }
 }


### PR DESCRIPTION
Add status.keyman.com as another dockerized website.

Add overloads for live site hostnames to all proxy records. It can be helpful to accept requests e.g. for keyman.com as well as keyman.com.localhost, when testing apps which may have hardcoded URLs (where we setup DNS overrides e.g. in /etc/hosts).

Test-bot: skip